### PR TITLE
Multiple logical networks with different interface names for same pod

### DIFF
--- a/genie/genie-controller.go
+++ b/genie/genie-controller.go
@@ -477,7 +477,6 @@ func getPodAnnotationsForCNI(client *kubernetes.Clientset, k8sArgs utils.K8sArgs
 // - Returns string
 func ParsePodAnnotationsForNetworks(client *kubernetes.Clientset, k8sArgs utils.K8sArgs) string {
 	annot, _ := getK8sPodAnnotations(client, k8sArgs)
-	fmt.Fprintf(os.Stderr, "CNI Genie annot= [%s]\n", annot)
 	networks := annot["networks"]
 	return networks
 }


### PR DESCRIPTION
Addressed issue where interface names for multiple logical networks being assigned with the same value
Test report: [test_report_multiple_networks.docx](https://github.com/Huawei-PaaS/CNI-Genie/files/2772674/test_report_multiple_networks.docx)
