### PR TITLE
fix CI failure: use apps/v1 for DaemonSet in yamls

### DIFF
--- a/conf/1.8/genie-complete.yaml
+++ b/conf/1.8/genie-complete.yaml
@@ -149,7 +149,7 @@ data:
 ---
 # Install CNI-Genie plugin on each slave node.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: genie-plugin
   namespace: kube-system
@@ -209,8 +209,8 @@ spec:
 ---
 # Genie network admission controller daemonset configuration
 # Genie network admission controller pods will run only in master nodes
-apiVersion: extensions/v1beta1
 kind: DaemonSet
+apiVersion: apps/v1
 metadata:
   name: genie-network-admission-controller
   namespace: kube-system
@@ -259,7 +259,7 @@ spec:
 ---
 # Daemonset configuration for geine network policy
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: genie-policy-controller
   namespace: kube-system

--- a/conf/1.8/genie-plugin.yaml
+++ b/conf/1.8/genie-plugin.yaml
@@ -106,7 +106,7 @@ data:
 ---
 # Install CNI-Genie plugin on each slave node.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: genie-plugin
   namespace: kube-system
@@ -166,8 +166,8 @@ spec:
 ---
 # Genie network admission controller daemonset configuration
 # Genie network admission controller pods will run only in master nodes
-apiVersion: extensions/v1beta1
 kind: DaemonSet
+apiVersion: apps/v1
 metadata:
   name: genie-network-admission-controller
   namespace: kube-system


### PR DESCRIPTION
API group `extensions/v1beta1` has been deprecated, this PR is to update yamls, use `apps/v1` instead.