### PR TITLE
Add missing '.spec.selector' field.

### DIFF
--- a/conf/1.8/genie-complete.yaml
+++ b/conf/1.8/genie-complete.yaml
@@ -215,6 +215,9 @@ metadata:
   name: genie-network-admission-controller
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      role: genie-network-admission-controller
   template:
     metadata:
       labels:

--- a/conf/1.8/genie-plugin.yaml
+++ b/conf/1.8/genie-plugin.yaml
@@ -172,6 +172,9 @@ metadata:
   name: genie-network-admission-controller
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      role: genie-network-admission-controller
   template:
     metadata:
       labels:


### PR DESCRIPTION
Currently, installation from the provided manifests fails with the following error:

```shell
$ kubectl apply -f https://raw.githubusercontent.com/cni-genie/CNI-Genie/master/conf/1.8/genie-plugin.yaml
(...)
error: error validating "https://raw.githubusercontent.com/cni-genie/CNI-Genie/master/conf/1.8/genie-plugin.yaml": error validating data: ValidationError(DaemonSet.spec): missing required field "selector" in io.k8s.api.apps.v1.DaemonSetSpec; if you choose to ignore these
errors, turn validation off with --validate=false
```

This PR fixes this issue by adding the missing `.spec.selector` field to both manifests.