### PR TITLE
Fix cniVersion(#201) and selector validation(#203) issues in genie manifest file

### DIFF
--- a/conf/1.8/genie-complete.yaml
+++ b/conf/1.8/genie-complete.yaml
@@ -131,6 +131,7 @@ data:
     {
         "name": "k8s-pod-network",
         "type": "genie",
+        "cniVersion": "0.2.0",
         "log_level": "info",
         "datastore_type": "kubernetes",
         "hostname": "__KUBERNETES_NODE_NAME__",

--- a/conf/1.8/genie-complete.yaml
+++ b/conf/1.8/genie-complete.yaml
@@ -214,7 +214,12 @@ apiVersion: apps/v1
 metadata:
   name: genie-network-admission-controller
   namespace: kube-system
+  labels:
+    role: genie-network-admission-controller
 spec:
+  selector:
+    matchLabels:
+      role: genie-network-admission-controller
   template:
     metadata:
       labels:

--- a/conf/1.8/genie-plugin.yaml
+++ b/conf/1.8/genie-plugin.yaml
@@ -88,6 +88,7 @@ data:
     {
         "name": "k8s-pod-network",
         "type": "genie",
+        "cniVersion": "0.2.0",
         "log_level": "info",
         "datastore_type": "kubernetes",
         "hostname": "__KUBERNETES_NODE_NAME__",

--- a/conf/1.8/genie-plugin.yaml
+++ b/conf/1.8/genie-plugin.yaml
@@ -171,7 +171,12 @@ apiVersion: apps/v1
 metadata:
   name: genie-network-admission-controller
   namespace: kube-system
+  labels:
+    role: genie-network-admission-controller
 spec:
+  selector:
+    matchLabels:
+      role: genie-network-admission-controller
   template:
     metadata:
       labels:

--- a/e2e/scripts/kube-cluster.sh
+++ b/e2e/scripts/kube-cluster.sh
@@ -22,6 +22,6 @@ kubectl taint nodes --all node-role.kubernetes.io/master-
 
 kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 
-kubectl apply -f https://raw.githubusercontent.com/cni-genie/CNI-Genie/master/conf/1.8/genie-complete.yaml
+kubectl apply -f conf/1.8/genie-complete.yaml
 
 


### PR DESCRIPTION
Fix for issues #201, #203 

**Test Report:**
```
root@master:~# kubectl apply -f genie-complete.yaml
clusterrole.rbac.authorization.k8s.io/genie-plugin created
clusterrole.rbac.authorization.k8s.io/genie-policy created
clusterrolebinding.rbac.authorization.k8s.io/genie-plugin created
clusterrolebinding.rbac.authorization.k8s.io/genie-policy created
serviceaccount/genie-plugin created
serviceaccount/genie-policy created
configmap/genie-config created
daemonset.apps/genie-plugin created
daemonset.apps/genie-network-admission-controller created
service/genie-network-admission-controller created
daemonset.apps/genie-policy-controller created
root@master:~# 

root@master:~# kubectl apply -f genie-plugin.yaml
clusterrole.rbac.authorization.k8s.io/genie-plugin created
clusterrolebinding.rbac.authorization.k8s.io/genie-plugin created
serviceaccount/genie-plugin created
configmap/genie-config created
daemonset.apps/genie-plugin created
daemonset.apps/genie-network-admission-controller created
service/genie-network-admission-controller created
root@master:~# 
```
