### PR TITLE
Config query on multi node policy deployment

### DIFF
--- a/controllers/network-policy-controller/main.go
+++ b/controllers/network-policy-controller/main.go
@@ -18,6 +18,7 @@ import (
 
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	clientset "github.com/cni-genie/CNI-Genie/controllers/logicalnetwork-pkg/client/clientset/versioned"
@@ -32,15 +33,22 @@ var (
 	kubeconfig string
 )
 
+func getConfig(kubeconfig string) (*rest.Config, error) {
+	if kubeconfig != "" {
+		return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
+	return rest.InClusterConfig()
+}
+
 func main() {
 	flag.Parse()
 
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
-	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+	cfg, err := getConfig("")
 	if err != nil {
-		glog.Fatalf("Error building kubeconfig: %s", err.Error())
+		glog.Fatalf("Error getting kubeconfig: %s", err.Error())
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)


### PR DESCRIPTION
```
root@net-iso-1:~# kubectl apply -f genie-complete.yaml 
clusterrole.rbac.authorization.k8s.io/genie-plugin created
clusterrole.rbac.authorization.k8s.io/genie-policy created
clusterrolebinding.rbac.authorization.k8s.io/genie-plugin created
clusterrolebinding.rbac.authorization.k8s.io/genie-policy created
serviceaccount/genie-plugin created
serviceaccount/genie-policy created
configmap/genie-config created
daemonset.apps/genie-plugin created
daemonset.apps/genie-network-admission-controller created
service/genie-network-admission-controller created
daemonset.apps/genie-policy-controller created
root@net-iso-1:~# 
root@net-iso-1:~# kubectl get po --all-namespaces -o wide
NAMESPACE     NAME                                       READY   STATUS    RESTARTS   AGE     IP              NODE        NOMINATED NODE   READINESS GATES
kube-system   coredns-66bff467f8-b4tf8                   1/1     Running   0          4d      10.32.0.3       net-iso-1   <none>           <none>
kube-system   coredns-66bff467f8-x9scn                   1/1     Running   0          4d      10.32.0.2       net-iso-1   <none>           <none>
kube-system   etcd-net-iso-1                             1/1     Running   0          4d      172.16.104.29   net-iso-1   <none>           <none>
kube-system   genie-network-admission-controller-bcjn2   1/1     Running   0          84s     172.16.104.29   net-iso-1   <none>           <none>
kube-system   genie-plugin-k5k86                         1/1     Running   0          84s     172.16.104.32   net-iso-2   <none>           <none>
kube-system   genie-plugin-ztxc4                         1/1     Running   0          84s     172.16.104.29   net-iso-1   <none>           <none>
kube-system   genie-policy-controller-b77rn              1/1     Running   0          84s     172.16.104.29   net-iso-1   <none>           <none>
kube-system   genie-policy-controller-mbs5f              1/1     Running   0          84s     172.16.104.32   net-iso-2   <none>           <none>
kube-system   kube-apiserver-net-iso-1                   1/1     Running   0          4d      172.16.104.29   net-iso-1   <none>           <none>
kube-system   kube-controller-manager-net-iso-1          1/1     Running   0          4d      172.16.104.29   net-iso-1   <none>           <none>
kube-system   kube-flannel-ds-amd64-sspfc                1/1     Running   0          3d19h   172.16.104.29   net-iso-1   <none>           <none>
kube-system   kube-flannel-ds-amd64-vmfwd                1/1     Running   0          3d19h   172.16.104.32   net-iso-2   <none>           <none>
kube-system   kube-proxy-czcg9                           1/1     Running   0          4d      172.16.104.32   net-iso-2   <none>           <none>
kube-system   kube-proxy-wlvvz                           1/1     Running   0          4d      172.16.104.29   net-iso-1   <none>           <none>
kube-system   kube-scheduler-net-iso-1                   1/1     Running   0          4d      172.16.104.29   net-iso-1   <none>           <none>
kube-system   weave-net-69znn                            2/2     Running   0          4d      172.16.104.29   net-iso-1   <none>           <none>
kube-system   weave-net-7p2j5                            2/2     Running   1          4d      172.16.104.32   net-iso-2   <none>           <none>
root@net-iso-1:~# 
```

Close issue #207 
