### PR TITLE
Add Website Link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Without CNI-Genie, the orchestrator is bound to only a single CNI plugin. E.g., 
 [![Build Status](https://travis-ci.org/cni-genie/CNI-Genie.svg)](https://travis-ci.org/cni-genie/CNI-Genie)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cni-genie/CNI-Genie)](https://goreportcard.com/report/github.com/cni-genie/CNI-Genie)
 
+## Official Website  
+For more information, visit the [CNI-Genie Website](https://cnigenie.netlify.app/en/).
+
 Please feel free to post your feedback, questions on CNI-Genie [Slack channel](https://cni-genie.slack.com/)
 
 ## Demo


### PR DESCRIPTION
Fixed #236 

### Description:
This pull request adds the official website link to the README.md file of the CNI-Genie repository.

### Why is this needed?
- Provides users with easy access to the official website.
- Improves documentation completeness.
- Enhances the repository’s usability for new users and contributors.

### Checklist:
- [x] Added the website link in an appropriate section.
- [x] Verified formatting and correctness.
- [x] Ensured no other parts of the document were affected.